### PR TITLE
slight import changes

### DIFF
--- a/monotime.go
+++ b/monotime.go
@@ -7,12 +7,9 @@ package monotime
 
 import (
 	"time"
-	"unsafe"
-)
 
-// Make goimports import the unsafe package, which is required to be able
-// to use //go:linkname
-var _ = unsafe.Sizeof(0)
+	_ "unsafe"
+)
 
 //go:noescape
 //go:linkname nanotime runtime.nanotime

--- a/monotime_test.go
+++ b/monotime_test.go
@@ -4,9 +4,7 @@
 
 package monotime
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestNow(t *testing.T) {
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
`import _ "foo"` is a little cleaner than `import "foo"\n\n`var _ = foo.Bar`
